### PR TITLE
Prefix spendbundle with 0x

### DIFF
--- a/src/app/bridge/drivers/rpc.tsx
+++ b/src/app/bridge/drivers/rpc.tsx
@@ -8,10 +8,10 @@ export function sbToJSON(sb: any): any {
         puzzle_hash: "0x" + coinSpend.coin.puzzleHash.replace("0x", ""),
         amount: parseInt(coinSpend.coin.amount.toString())
       },
-      puzzle_reveal: GreenWeb.util.sexp.toHex(coinSpend.puzzleReveal),
-      solution: GreenWeb.util.sexp.toHex(coinSpend.solution)
+      puzzle_reveal: "0x" + GreenWeb.util.sexp.toHex(coinSpend.puzzleReveal),
+      solution: "0x" + GreenWeb.util.sexp.toHex(coinSpend.solution)
     })),
-    aggregated_signature: sb.aggregatedSignature
+    aggregated_signature: "0x" + sb.aggregatedSignature
   };
 }
 


### PR DESCRIPTION
I tried using my own full node RPC instead of the provided fireacademy.io one, but encountered an error when pushing the spendbundle (this is for chia-blockchain `2.3.0`). Correctly prefixing `puzzle_reveal`, `solution` and `aggregated_signature` with `0x` fixes the issue.

```
WARNING  Error while handling message: Traceback (most recent call last):
   File "chia/rpc/util.py", line 49, in inner
   File "chia/rpc/full_node_rpc_api.py", line 740, in push_tx
   File "chia/types/spend_bundle.py", line 67, in from_json_dict
   File "chia/util/streamable.py", line 202, in streamable_from_dict
   File "chia/util/streamable.py", line 202, in <dictcomp>
   File "chia/util/streamable.py", line 225, in <lambda>
   File "chia/util/streamable.py", line 158, in convert_list
   File "chia/util/streamable.py", line 158, in <listcomp>
   File "chia/util/streamable.py", line 227, in <lambda>
 ValueError: bytes object is expected to start with 0x
```

