### PR TITLE
Update catbridge.tsx to handle coins with large amounts

### DIFF
--- a/src/app/bridge/drivers/catbridge.tsx
+++ b/src/app/bridge/drivers/catbridge.tsx
@@ -529,7 +529,7 @@ export async function unlockCATs(
   const lockedCoins: InstanceType<typeof GreenWeb.Coin>[] = coinRecords.map((coinRecord: any) => GreenWeb.util.goby.parseGobyCoin({
     parent_coin_info: GreenWeb.util.unhexlify(coinRecord.coin.parent_coin_info),
     puzzle_hash: GreenWeb.util.unhexlify(coinRecord.coin.puzzle_hash),
-    amount: coinRecord.coin.amount
+    amount: String(coinRecord.coin.amount)
   })!);
 
   if(tokenTailHash !== null) {


### PR DESCRIPTION
Resolve an issue where `GreenWeb.util.goby.parseGobyCoin` will not process a coin if amount is a number and a large number.