### PR TITLE
Use different metadata names for Wallet Connect(ETH and XCH)

### DIFF
--- a/src/app/bridge/ChiaWalletManager/wallets/walletconnect.tsx
+++ b/src/app/bridge/ChiaWalletManager/wallets/walletconnect.tsx
@@ -1,4 +1,4 @@
-import { TESTNET, TOKENS, WALLETCONNECT_PROJECT_ID_XCH, WcMetadata } from '../../config'
+import { TESTNET, TOKENS, WALLETCONNECT_PROJECT_ID_XCH, xchWcMetadata } from '../../config'
 import SignClient from '@walletconnect/sign-client'
 import { SessionTypes } from '@walletconnect/types'
 import { addCATParams, createOfferParams } from './types'
@@ -107,7 +107,7 @@ function getFingerprint(session: SessionTypes.Struct) {
 async function getClient() {
   const signClient = await SignClient.init({
     projectId: WALLETCONNECT_PROJECT_ID_XCH,
-    metadata: WcMetadata,
+    metadata: xchWcMetadata,
     storage: new CustomWalletConnectStorage("chia-wc-data")
   })
 

--- a/src/app/bridge/config.tsx
+++ b/src/app/bridge/config.tsx
@@ -412,8 +412,14 @@ declare module 'wagmi' {
 export const WALLETCONNECT_PROJECT_ID_ETH = 'e47a64f2fc7214f6c9f71b8b71e5e786'
 export const WALLETCONNECT_PROJECT_ID_XCH = '777b63154ba9ec11877caf45a17b523e'
 
-export const WcMetadata = {
-  name: 'warp.green Bridge Interface',
+export const xchWcMetadata = {
+  name: 'warp.green Bridge XCH Interface',
+  description: 'Bridging powered by the warp.green cross-chain messaging protocol',
+  url: 'https://warp.green',
+  icons: ['https://testnet.warp.green/warp-green-icon.png']
+}
+export const ethWcMetadata = {
+  name: 'warp.green Bridge ETH Interface',
   description: 'Bridging powered by the warp.green cross-chain messaging protocol',
   url: 'https://warp.green',
   icons: ['https://testnet.warp.green/warp-green-icon.png']
@@ -426,7 +432,7 @@ export const wagmiConfig = defaultWagmiConfig({
   ],
   projectId: WALLETCONNECT_PROJECT_ID_ETH,
   ssr: true,
-  metadata: WcMetadata,
+  metadata: ethWcMetadata,
   transports: {
     [TESTNET ? baseSepolia.id : base.id]: http(BASE_NETWORK.rpcUrl),
     [TESTNET ? sepolia.id : mainnet.id]: http(ETHEREUM_NETWORK.rpcUrl),

--- a/src/app/bridge/wc/page.tsx
+++ b/src/app/bridge/wc/page.tsx
@@ -5,7 +5,7 @@ import { Suspense, useEffect, useState } from "react";
 import { useWallet } from "../ChiaWalletManager/WalletContext";
 import { useAccount} from "wagmi";
 import { EthereumProvider } from '@walletconnect/ethereum-provider'
-import { BASE_NETWORK, ETHEREUM_NETWORK, TESTNET, WALLETCONNECT_PROJECT_ID_ETH, WcMetadata } from "../config";
+import { BASE_NETWORK, ETHEREUM_NETWORK, TESTNET, WALLETCONNECT_PROJECT_ID_ETH, ethWcMetadata, xchWcMetadata } from "../config";
 import { base, baseSepolia, mainnet, sepolia } from "viem/chains";
 
 export default function SuspensefulComponent() {
@@ -53,7 +53,7 @@ function WalletConnectAutoConnect() {
             TESTNET ? sepolia.id : mainnet.id,
           ],
           projectId: WALLETCONNECT_PROJECT_ID_ETH,
-          metadata: WcMetadata,
+          metadata: ethWcMetadata,
           showQrModal: false,
           rpcMap: {
             [BASE_NETWORK.chainId!]: BASE_NETWORK.rpcUrl,


### PR DESCRIPTION
If a same wallet are used to create the both Wallet Connect sessions is necessary have differentes names to can clean old wallet connect sessions and avoid malfunctions mixing old and new Wallet Connect sessions