### PR TITLE
Add PEPE

### DIFF
--- a/src/app/bridge/config.tsx
+++ b/src/app/bridge/config.tsx
@@ -511,6 +511,25 @@ export const BEPE_MEMECOIN_TOKEN_BASE_ONLY: Token = {
   additionalWarning: null,
 }
 
+const PEPE_MEMECOIN_ASSET_ID_BASE_MAINNET = 'ec9d874e152e888231024c72e391fc484e8b6a1cf744430a322a0544e207bf46'
+const PEPE_MEMECOIN_ADDRESS_BASE_MAINNET = '0xC71690cd048F30F58Eee0d138fc19647bDaD79C7'
+
+export const PEPE_MEMECOIN_TOKEN_BASE_ONLY: Token = {
+  symbol: 'PEPE',
+  getSpecificSymbol: makeCoinsetNativeToken('PEPE'),
+  sourceNetworkType: NetworkType.COINSET,
+  supported: [
+    {
+      evmNetworkId: BASE_NETWORK.id,
+      coinsetNetworkId: CHIA_NETWORK.id,
+      assetId: PEPE_MEMECOIN_ASSET_ID_BASE_MAINNET,
+      contractAddress: PEPE_MEMECOIN_ADDRESS_BASE_MAINNET
+    },
+  ],
+  memecoin: true,
+  additionalWarning: "This PEPE is a Chia-based CAT not connected to the memecoins launched on other chains.",
+}
+
 
 export const TOKENS = TESTNET ? [
   ETH_TOKEN,
@@ -528,7 +547,8 @@ export const TOKENS = TESTNET ? [
   USDT_TOKEN,
   HOA_TOKEN_BASE_ONLY,
   WARP_MEMECOIN_TOKEN_BASE_ONLY,
-  BEPE_MEMECOIN_TOKEN_BASE_ONLY
+  BEPE_MEMECOIN_TOKEN_BASE_ONLY,
+  PEPE_MEMECOIN_TOKEN_BASE_ONLY
 ]
 
 declare module 'wagmi' {


### PR DESCRIPTION
CAT Asset Id              | ec9d874e152e888231024c72e391fc484e8b6a1cf744430a322a0544e207bf46
:-------------------------|:----
SpaceScan CAT Page        | [https://www.spacescan.io/token/PEPE](https://www.spacescan.io/token/PEPE)
Dexie CAT Page            | [https://dexie.space/assets/PEPE](https://dexie.space/assets/PEPE)
TibetSwap Pair Page       | [PEPE Pair](https://v2.tibetswap.io/pair/b62577aed2b09182f3db8b21049d687b597f1526fb88268c1b4f4dec4add28ec)
Base Contract Address     | [0xC71690cd048F30F58Eee0d138fc19647bDaD79C7](https://basescan.org/address/0xC71690cd048F30F58Eee0d138fc19647bDaD79C7)
Docs PR                   | [Docs PR](https://github.com/warpdotgreen/docs/pull/2)
Watcher PR                | [Watcher PR](https://github.com/warpdotgreen/watcher/pull/1)
Test Bridge (XCH -> Base) | [BaseScan](https://basescan.org/tx/0x92980c36573714d4fa9cc642d6bb42b25ef1a4696f85fad8126be94e3394d649)
Test Bridge (Base -> XCH) | [SpaceScan](https://spacescan.io/coin/0x1b03f1d7b58ff8d0396abf865bfcf80ef5768f1613176785bc3960c605f81d26)

## Process Steps

**Do not modify anything after this sentence.** The maintainer handling this listing request will take the steps below (subject to change). As mentioned in the documentation, the warp.green team reserves the right to approve/reject pull requests on a case-by-case basis.
 * Ensure information (token name & symbol) is consistent across SpaceScan, Dexie, and TibetSwap
 * Ensure no other well-known CATs use the same ticker
 * Verify that the Base contract contains the correct code and has been initialized with the correct puzzle hashes (via CLI)
 * Check the current PR changes. If the token ticker might be misleading, make sure an appropriate `additionalWarning` is set.
 * Check test bridging transactions were correct and successful
 * Check & approve the documentation PR
 * Check & approve the watcher PR
 * Update the watcher to run the latest version
 * Approve this PR