### PR TITLE
Add $HORSE

### DIFF
--- a/src/app/bridge/config.tsx
+++ b/src/app/bridge/config.tsx
@@ -1234,6 +1234,25 @@ export const WESO_TOKEN_BASE_ONLY: Token = {
   additionalWarning: 'WESO is the Chia-based reward token of weso.forgeros.fr. Listing on this interface does NOT represent endorsement from the warp.green team. Do your own research before transacting with WESO.',
 }
 
+const HORSE_MEMECOIN_ASSET_ID_BASE_MAINNET = '1efff18fedcdb63818a1b41ab3e977707bc314a090e7ea5db396a56095290604'
+const HORSE_MEMECOIN_ADDRESS_BASE_MAINNET = '0x827fc57Bc514578E8280cEE73f5e948D306aF074'
+
+export const HORSE_MEMECOIN_TOKEN_BASE_ONLY: Token = {
+  symbol: '$HORSE',
+  getSpecificSymbol: makeCoinsetNativeToken('$HORSE'),
+  sourceNetworkType: NetworkType.COINSET,
+  supported: [
+    {
+      evmNetworkId: BASE_NETWORK.id,
+      coinsetNetworkId: CHIA_NETWORK.id,
+      assetId: HORSE_MEMECOIN_ASSET_ID_BASE_MAINNET,
+      contractAddress: HORSE_MEMECOIN_ADDRESS_BASE_MAINNET
+    },
+  ],
+  memecoin: true,
+  additionalWarning: null,
+}
+
 export const TOKENS = TESTNET ? [
   ETH_TOKEN,
   USDT_TOKEN,
@@ -1289,7 +1308,8 @@ export const TOKENS = TESTNET ? [
   NWO_MEMECOIN_TOKEN_BASE_ONLY,
   PLANK_MEMECOIN_TOKEN_BASE_ONLY,
   MINUTES_MEMECOIN_TOKEN_BASE_ONLY,
-  WESO_TOKEN_BASE_ONLY
+  WESO_TOKEN_BASE_ONLY,
+  HORSE_MEMECOIN_TOKEN_BASE_ONLY,
 ]
 
 declare module 'wagmi' {


### PR DESCRIPTION
CAT Asset Id              | [1efff18fedcdb63818a1b41ab3e977707bc314a090e7ea5db396a56095290604](https://spacescan.io/token/1efff18fedcdb63818a1b41ab3e977707bc314a090e7ea5db396a56095290604)
:-------------------------|:----
Base Contract Address     | [0x827fc57Bc514578E8280cEE73f5e948D306aF074](https://basescan.org/address/0x827fc57Bc514578E8280cEE73f5e948D306aF074)
Docs PR                   | [here](https://github.com/warpdotgreen/docs/pull/12)
Watcher PR                | [here](https://github.com/warpdotgreen/watcher/pull/12)
Test Bridge (XCH -> Base) | [explorer](https://basescan.org/tx/0xe15bc9009eef6d4b568ef76509385458771f0edda6fc9d7220264fbfbf6fc0fb)
Test Bridge (Base -> XCH) | [explorer](https://spacescan.io/coin/0xc2fc5e2cf2bfedcb22c481733aeca9d7bd502b72d128c74d88b09a38c5f61254)

## Process Steps

**Do not modify anything after this sentence.** The maintainer handling this listing request will take the steps below (subject to change). As mentioned in the documentation, the warp.green team reserves the right to approve/reject pull requests on a case-by-case basis.
 * Ensure information (token name & symbol) is consistent across SpaceScan, Dexie, and TibetSwap
 * Ensure no other well-known CATs use the same ticker
 * Verify that the Base contract contains the correct code and has been initialized with the correct puzzle hashes (via CLI)
 * Check the current PR changes. If the token ticker might be misleading, make sure an appropriate `additionalWarning` is set.
 * Check test bridging transactions were correct and successful
 * Check & approve the documentation PR
 * Check & approve the watcher PR
 * Update the watcher to run the latest version
 * Approve this PR